### PR TITLE
Fix wait for start after restore

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -86,3 +86,5 @@ sudo mongorestore ./dump
 #=================================================
 
 sudo systemctl start rocketchat
+waitforservice
+


### PR DESCRIPTION
Final Stage at ci-tests (package-checker) fail because restore script doesnt wait until backend service is started properly [see here](https://ci-apps.yunohost.org/jenkins/view/Community/job/rocketchat%20(Community)/6/console). This fix is including waitforservice method used in install script.