### PR TITLE
Fixes ynh_die not found and port variable unbound

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -7,8 +7,8 @@ set -eu
 # IMPORT GENERIC HELPERS
 #=================================================
 
-source ./_common.sh
 source /usr/share/yunohost/helpers
+source ./_common.sh
 
 #=================================================
 # MANAGE SCRIPT FAILURE

--- a/scripts/remove
+++ b/scripts/remove
@@ -7,8 +7,8 @@ set -u
 # IMPORT GENERIC HELPERS
 #=================================================
 
-source ./_common.sh
 source /usr/share/yunohost/helpers
+source ./_common.sh
 
 app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get $app domain)

--- a/scripts/restore
+++ b/scripts/restore
@@ -9,8 +9,8 @@ if [ ! -e _common.sh ]; then
 	sudo cp ../settings/scripts/_common.sh ./_common.sh
 	sudo chmod a+rx _common.sh
 fi
-source _common.sh
 source /usr/share/yunohost/helpers
+source _common.sh
 
 #=================================================
 # GENERIC START
@@ -31,6 +31,7 @@ domain=$(ynh_app_setting_get $app domain)
 path=$(ynh_app_setting_get $app path)
 final_path=$(ynh_app_setting_get $app final_path)
 serviceuser=$(ynh_app_setting_get $app serviceuser)
+port=$(ynh_app_setting_get $app port)
 
 # Check domain/path availability
 sudo yunohost app checkurl "${domain}${path}" -a "$app" || ynh_die
@@ -87,4 +88,3 @@ sudo mongorestore ./dump
 
 sudo systemctl start rocketchat
 waitforservice
-


### PR DESCRIPTION
ci failed again [see here](https://ci-apps.yunohost.org/jenkins/view/Community/job/rocketchat%20(Community)/8/consoleFull)

This time port variable used in waitforservice is not set in restore (so all restores fail) and also ynh_die fails due to helpers that are included after common tools.

This merge request adresses both issues in all scripts that are affected.