### PR TITLE
Fixes download locations

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -82,8 +82,8 @@ sed -i "s@#DESTDIR#@$final_path@g"  ../conf/nginx.conf
 sudo cp ../conf/nginx.conf "$nginx_conf"
 
 # download and extract rocketchat
-echo "Downloading rocket.chat-$ROCKETCHAT_VERSION.gtar from https://rocket.chat/releases/${ROCKETCHAT_VERSION}/download."
-sudo curl -s -L -o $final_path/rocket.chat-$ROCKETCHAT_VERSION.gtar "https://rocket.chat/releases/${ROCKETCHAT_VERSION}/download"
+echo "Downloading rocket.chat-$ROCKETCHAT_VERSION.gtar from https://download.rocket.chat/build/rocket.chat-${ROCKETCHAT_VERSION}.tgz."
+sudo curl -s -L -o $final_path/rocket.chat-$ROCKETCHAT_VERSION.gtar "https://download.rocket.chat/build/rocket.chat-${ROCKETCHAT_VERSION}.tgz"
 SHA_DOWNLOAD=$(sha256sum $final_path/rocket.chat-$ROCKETCHAT_VERSION.gtar | grep -o "^[a-f0-9]*")
 if [[ ! "$SHA_DOWNLOAD" == "$ROCKETCHAT_SHASUM" ]]; then
   ynh_die "The sha256sum does not match the configured one"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,7 +24,7 @@ sudo rm -rf $final_path
 sudo mkdir -p $final_path
 
 # upgrade to the latest rocketchat
-sudo curl -s -L -o $final_path/rocket.chat-latest.gtar "https://rocket.chat/releases/latest/download"
+sudo curl -s -L -o $final_path/rocket.chat-latest.gtar "https://download.rocket.chat/stable"
 sudo tar -xzf $final_path/rocket.chat-latest.gtar -C $final_path --strip-components=1 bundle
 sudo rm $final_path/rocket.chat-latest.gtar
 


### PR DESCRIPTION
Currently the bundled rocket.chat download urls are changed to download.rocket.chat/build/rocket.chat-VERSION.tgz.

On their website they only refer to the latest tgz and the github source download links.

Looking up the docker buildfiles of the official rocketchat docker images I was able to gather information about the current download url and applied this change.

Note: Current CI is failing due to this (shasum compare error because 404 page is downloaded instead).