### PR TITLE
Fix mongosh call syntax ?

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -109,7 +109,7 @@ ynh_mongo_exec() {
             database=""
         fi
 
-        mongosh --quiet --username $user --password $password --authenticationDatabase $authenticationdatabase --host $host --port $port <<EOF
+        mongosh --quiet $user $password $authenticationdatabase $host $port <<EOF
 $database
 ${command}
 quit()
@@ -123,7 +123,7 @@ EOF
             database=""
         fi
         
-        mongosh --quiet $database --username $user --password $password --authenticationDatabase $authenticationdatabase --host $host --port $port --eval="$command"
+        mongosh --quiet $database $user $password $authenticationdatabase $host $port --eval="$command"
     fi
 }
 


### PR DESCRIPTION
## Problem

I don't know how the mongodb helpers are supposed to work but the current script is pretty funky ... 

Some user complained that rocket chat fails to install with the following logs:

```
2022-12-04 01:09:03,510: DEBUG - + ynh_mongo_setup_db --db_user=rocketchat --db_name=rocketchat
[...]
2022-12-04 01:09:03,534: DEBUG - + ynh_mongo_create_user --db_user=rocketchat --db_pwd=********** --db_name=rocketchat
2022-12-04 01:09:03,562: DEBUG - + ynh_mongo_exec --database=rocketchat '--command=db.createUser( { user: "rocketchat", pwd: "**********", roles: [ { role: "readWrite", db: "rocketchat" } ] } );'
2022-12-04 01:09:03,607: DEBUG - + user=
2022-12-04 01:09:03,607: DEBUG - + password=
2022-12-04 01:09:03,607: DEBUG - + authenticationdatabase=
2022-12-04 01:09:03,607: DEBUG - + database=rocketchat
2022-12-04 01:09:03,608: DEBUG - + host=
2022-12-04 01:09:03,608: DEBUG - + port=
2022-12-04 01:09:03,608: DEBUG - + eval=0
2022-12-04 01:09:03,608: DEBUG - + '[' -n '' ']'
2022-12-04 01:09:03,608: DEBUG - + password=
2022-12-04 01:09:03,608: DEBUG - + authenticationdatabase=
2022-12-04 01:09:03,608: DEBUG - + '[' -n '' ']'
2022-12-04 01:09:03,608: DEBUG - + '[' -n '' ']'
2022-12-04 01:09:03,608: DEBUG - + '[' -n rocketchat ']'
2022-12-04 01:09:03,608: DEBUG - + database='use rocketchat'
2022-12-04 01:09:03,608: DEBUG - + mongosh --quiet --username --password --authenticationDatabase --host --port
2022-12-04 01:09:04,496: WARNING - MongoNetworkError: connect ECONNREFUSED 127.0.0.1:27017
```

Notice the N-1 line:

```
mongosh --quiet --username --password --authenticationDatabase --host --port
```

It's like a bunch of arguments are passed, but it's all missing values like `--username=someuser`

Looking at the code, `$user` is supposed to be `--username=someuser` OR empty ... but then it's used with `--username $user`, so the actual call ends up being either `--username` (no value) or `--username --username=someuser` (duplicate --username)

## Solution

Rewrite the `mongosh` call. This should be backported to https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_mongo_db/ynh_mongo_db__2

But what's really puzzling is that the app does seem to work on the CI ... the complete log shows:

```
DEBUG + mongosh --quiet --username --password --authenticationDatabase --host --port
DEBUG test> switched to db rocketchat
DEBUG rocketchat> { ok: 1 }
```

so the issue is present in the CI but somehow that works x_x

(ping @yalh76 in case you have some better idea of what's going on ...)

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
